### PR TITLE
Rsync deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "main": "./client/index.js",
   "scripts": {
     "dist": "NODE_ENV=production gulp dist",
-    "prod:deploy": "ssh gingerhq.com 'sudo salt-call state.sls projects.threads'",
-    "deploy": "ssh dev.gingerhq.com 'sudo salt-call state.sls projects.threads'"
+    "prod:deploy": "rsync -avz --chmod=g+w --omit-dir-times --delete ./dist/ usethreads.com:/var/www/usethreads.com",
+    "deploy": "rsync -avz --chmod=g+w --omit-dir-times --delete ./dist/ dev.usethreads.com:/var/www/dev.usethreads.com"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This command is a bit dangerous in that whatever is in your `dist` folder will replace what's live on the server. Should we force a successful `npm run dist` first?
